### PR TITLE
fix: force ssh to use IPv4 and only the generated SSH key

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -294,6 +294,8 @@ in
           UserKnownHostsFile /dev/null
           HostKeyAlias ${sshHostKeyAlias}
           Hostname localhost
+          AddressFamily inet
+          IdentitiesOnly yes
           IdentityFile ${workingDirectory}/${sshUserPrivateKeyFileName}
           Port ${toString cfg.port}
           StrictHostKeyChecking yes


### PR DESCRIPTION
The launchd daemon only listen to IPv4 but ssh may resolve localhost as ::1 preventing the onDemand boot to work.

This commit explicitly tells ssh to use IPv4 to resolve virby-vm

It also instructs ssh to only attempt a login with the specified IdentityFile. This is important to avoid the "too many login attempts" error in a system with many ssh identities in the ssh agent.