### PR TITLE
Fix SSH user key handling and launchd socket activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you prefer building the image locally, you can enable the `nix.linux-builder`
 ```nix
 {
   services.virby.debug = true;         # Enable verbose logging
-  services.virby.allowUserSsh = true;  # Allow non-root SSH access
+  services.virby.allowUserSsh = true;  # Allow non-root SSH access with a separate shared key copy
 }
 ```
 

--- a/lib/constants.nix
+++ b/lib/constants.nix
@@ -10,6 +10,7 @@ let
   sshHostPublicKeyFileName = sshHostPrivateKeyFileName + ".pub";
   sshKnownHostsFileName = "ssh_known_hosts";
   sshUserPrivateKeyFileName = "ssh_user_ed25519_key";
+  sshUserPrivateKeySharedFileName = sshUserPrivateKeyFileName + ".shared";
   sshUserPublicKeyFileName = sshUserPrivateKeyFileName + ".pub";
   vmHostName = "virby-vm";
   vmUser = "builder";
@@ -28,6 +29,7 @@ in
     sshHostPublicKeyFileName
     sshKnownHostsFileName
     sshUserPrivateKeyFileName
+    sshUserPrivateKeySharedFileName
     sshUserPublicKeyFileName
     vmHostName
     vmUser

--- a/module/default.nix
+++ b/module/default.nix
@@ -15,6 +15,7 @@ let
     sshHostPublicKeyFileName
     sshKnownHostsFileName
     sshUserPrivateKeyFileName
+    sshUserPrivateKeySharedFileName
     sshUserPublicKeyFileName
     vmHostName
     vmUser
@@ -108,20 +109,18 @@ let
       local temp_dir=$(mktemp -d)
       local temp_host_key="$temp_dir/host_key"
       local temp_user_key="$temp_dir/user_key"
-      local user_key_required_mode=${if cfg.allowUserSsh then "644" else "600"}
 
       trap "rm -rf $temp_dir" RETURN
 
       ssh-keygen -C ${darwinUser}@darwin -f "$temp_user_key" -N "" -t ed25519 || return 1
       ssh-keygen -C root@${vmHostName} -f "$temp_host_key" -N "" -t ed25519 || return 1
 
-      # Set permissions based on `cfg.allowUserSsh`
       chmod 640 "$temp_host_key.pub" "$temp_user_key.pub"
       chmod 600 "$temp_host_key"
-      chmod "$user_key_required_mode" "$temp_user_key"
+      chmod 600 "$temp_user_key"
 
       # Remove old keys if they exist
-      rm -f ${sshUserPrivateKeyFileName} ${sshHostPublicKeyFileName}
+      rm -f ${sshUserPrivateKeyFileName} ${sshUserPrivateKeySharedFileName} ${sshHostPublicKeyFileName}
       rm -rf ${sshdKeysSharedDirName}
 
       echo "${sshHostKeyAlias} $(cat $temp_host_key.pub)" > ${sshKnownHostsFileName}
@@ -176,9 +175,8 @@ let
       fi
     fi
 
-    # If `cfg.allowUserSsh` is true, the user key should be group-readable, otherwise it
-    # should be owner-only
-    user_key_required_mode=${if cfg.allowUserSsh then "644" else "600"}
+    # The runner always uses the private key directly, so it must stay owner-only.
+    user_key_required_mode=600
     user_key_actual_mode=$(stat -c "%a" ${sshUserPrivateKeyFileName} 2>/dev/null)
 
     if [[ $user_key_required_mode -ne $user_key_actual_mode ]]; then
@@ -188,15 +186,29 @@ let
       fi
     fi
 
-    if ! chmod 'go+r' ${sshKnownHostsFileName}; then
-      ${logError} "Failed to set permissions on ${sshKnownHostsFileName}"
+    if [[ ${if cfg.allowUserSsh then "1" else "0"} -eq 1 ]]; then
+      if ! cp -f ${sshUserPrivateKeyFileName} ${sshUserPrivateKeySharedFileName}; then
+        ${logError} "Failed to create shared SSH key copy"
+        exit 1
+      fi
+
+      if ! chmod 644 ${sshUserPrivateKeySharedFileName}; then
+        ${logError} "Failed to set permissions on ${sshUserPrivateKeySharedFileName}"
+        exit 1
+      fi
+    else
+      rm -f ${sshUserPrivateKeySharedFileName}
+    fi
+
+    if ! [[ -f ${sshHostPublicKeyFileName} ]]; then
+      ${logError} "Missing host public key: ${sshHostPublicKeyFileName}"
       exit 1
     fi
 
-    ${logInfo} "Starting VM..."
+    echo "${sshHostKeyAlias} $(cat ${sshHostPublicKeyFileName})" > ${sshKnownHostsFileName}
 
-    if ! exec virby-vm; then
-      ${logError} "Failed to start the VM"
+    if ! chmod 'go+r' ${sshKnownHostsFileName}; then
+      ${logError} "Failed to set permissions on ${sshKnownHostsFileName}"
       exit 1
     fi
   '';
@@ -304,6 +316,7 @@ in
         fi
 
         chown ${darwinUser}:${darwinGroup} ${workingDirectory}
+
       '';
 
       environment.etc."ssh/ssh_config.d/100-${vmHostName}.conf".text = ''
@@ -314,7 +327,9 @@ in
           Hostname localhost
           AddressFamily inet
           IdentitiesOnly yes
-          IdentityFile ${workingDirectory}/${sshUserPrivateKeyFileName}
+          IdentityFile ${workingDirectory}/${
+            if cfg.allowUserSsh then sshUserPrivateKeySharedFileName else sshUserPrivateKeyFileName
+          }
           Port ${toString cfg.port}
           StrictHostKeyChecking yes
           User ${vmUser}

--- a/module/default.nix
+++ b/module/default.nix
@@ -83,10 +83,11 @@ let
     }
   );
 
-  runnerScript = pkgs.writeShellScript "${daemonName}-runner" ''
+  prepareVmScript = pkgs.writeShellScript "${daemonName}-prepare-vm" ''
     PATH=${binPath}:$PATH
 
     set -euo pipefail
+    cd ${workingDirectory}
 
     NEEDS_GENERATE_SSH_KEYS=0
 
@@ -317,6 +318,13 @@ in
 
         chown ${darwinUser}:${darwinGroup} ${workingDirectory}
 
+        logInfo "Preparing Virby VM runtime files..."
+        if ! ${prepareVmScript}; then
+          logError "Failed to prepare Virby VM runtime files"
+          exit 1
+        fi
+
+        chown -R ${darwinUser}:${darwinGroup} ${workingDirectory}
       '';
 
       environment.etc."ssh/ssh_config.d/100-${vmHostName}.conf".text = ''
@@ -337,8 +345,17 @@ in
 
       launchd.daemons = {
         ${daemonName} = {
-          path = [ "/bin" ];
-          command = runnerScript;
+          path =
+            with pkgs;
+            [
+              coreutils
+              findutils
+              gnugrep
+              nix
+              openssh
+              self.packages.${pkgs.stdenv.hostPlatform.system}.vm-runner
+            ];
+          command = "${lib.getExe self.packages.${pkgs.stdenv.hostPlatform.system}.vm-runner}";
 
           serviceConfig = {
             UserName = darwinUser;

--- a/module/default.nix
+++ b/module/default.nix
@@ -355,7 +355,7 @@ in
               openssh
               self.packages.${pkgs.stdenv.hostPlatform.system}.vm-runner
             ];
-          command = "${lib.getExe self.packages.${pkgs.stdenv.hostPlatform.system}.vm-runner}";
+          command = lib.getExe self.packages.${pkgs.stdenv.hostPlatform.system}.vm-runner;
 
           serviceConfig = {
             UserName = darwinUser;

--- a/pkgs/vm-runner/src/virby_vm_runner/socket_activation.py
+++ b/pkgs/vm-runner/src/virby_vm_runner/socket_activation.py
@@ -131,7 +131,10 @@ class SocketActivation:
             if value:
                 logger.debug(f"Found env var {env_var}={value}")
 
-        for fd in range(3, 11):
+        # launchd can assign the inherited listener socket above the stdio range,
+        # and that layout changes depending on whether stdout/stderr are redirected.
+        # Scan a broader descriptor range so debug logging does not affect startup.
+        for fd in range(3, 256):
             test_sock = None
             try:
                 fd_stat = os.fstat(fd)

--- a/pkgs/vm-runner/src/virby_vm_runner/socket_activation.py
+++ b/pkgs/vm-runner/src/virby_vm_runner/socket_activation.py
@@ -6,29 +6,10 @@ import logging
 import os
 import socket
 import stat
-from contextlib import asynccontextmanager
 
 from .exceptions import VMStartupError
 
 logger = logging.getLogger(__name__)
-
-
-@asynccontextmanager
-async def managed_socket(fd: int, family: int, type: int):
-    """Context manager for socket file descriptors."""
-    sock = None
-    try:
-        sock = socket.fromfd(fd, family, type)
-        yield sock
-    except Exception as e:
-        logger.debug(f"Error with socket FD {fd}: {e}")
-        raise
-    finally:
-        if sock:
-            try:
-                sock.close()
-            except Exception as e:
-                logger.debug(f"Error closing socket FD {fd}: {e}")
 
 
 class SocketActivation:
@@ -47,30 +28,29 @@ class SocketActivation:
     def _call_launch_activate_socket(self, socket_name: str) -> list[int]:
         """Use launch_activate_socket to get socket file descriptors."""
         try:
-            # Load the System library which contains launch_activate_socket
-            libsystem = ctypes.CDLL(ctypes.util.find_library("System"))
+            libsystem_path = ctypes.util.find_library("System")
+            if not libsystem_path:
+                logger.debug("System library not found")
+                return []
 
-            # Verify function exists
+            libsystem = ctypes.CDLL(libsystem_path)
+
             if not hasattr(libsystem, "launch_activate_socket"):
                 logger.debug("launch_activate_socket not available")
                 return []
 
-            # Define the function signature
-            # int launch_activate_socket(const char *name, int **fds, size_t *cnt);
             launch_activate_socket = libsystem.launch_activate_socket
             launch_activate_socket.argtypes = [
-                ctypes.c_char_p,  # const char *name
-                ctypes.POINTER(ctypes.POINTER(ctypes.c_int)),  # int **fds
-                ctypes.POINTER(ctypes.c_size_t),  # size_t *cnt
+                ctypes.c_char_p,
+                ctypes.POINTER(ctypes.POINTER(ctypes.c_int)),
+                ctypes.POINTER(ctypes.c_size_t),
             ]
             launch_activate_socket.restype = ctypes.c_int
 
-            # Prepare parameters
             name_bytes = socket_name.encode("utf-8")
             fds_ptr = ctypes.POINTER(ctypes.c_int)()
             count = ctypes.c_size_t()
 
-            # Call the function
             result = launch_activate_socket(name_bytes, ctypes.byref(fds_ptr), ctypes.byref(count))
 
             if result != 0:
@@ -81,11 +61,7 @@ class SocketActivation:
                 logger.debug("launch_activate_socket returned 0 file descriptors")
                 return []
 
-            # Extract file descriptors from the returned array
-            fds = []
-            for i in range(count.value):
-                fds.append(fds_ptr[i])
-
+            fds = [fds_ptr[i] for i in range(count.value)]
             logger.debug(f"launch_activate_socket returned {count.value} file descriptors: {fds}")
             return fds
 
@@ -97,35 +73,52 @@ class SocketActivation:
         """Get the socket passed by launchd for activation."""
         logger.debug("Attempting to find activation socket...")
 
-        # Try proper launchd API first
         socket_fds = self._call_launch_activate_socket("Listener")
 
         if socket_fds:
             return self._process_launchd_sockets(socket_fds)
 
-        # Limited fallback scanning
         return self._fallback_socket_scan()
 
-    def _process_launchd_sockets(self, socket_fds: list[int]) -> socket.socket:
-        """Process sockets from launchd with proper cleanup."""
-        for fd in socket_fds:
-            try:
-                test_sock = socket.fromfd(fd, socket.AF_INET, socket.SOCK_STREAM)
-                sock_name = test_sock.getsockname()
-                logger.info(f"Found launchd socket on FD {fd}, bound to {sock_name}")
+    def _socket_matches_port(self, sock: socket.socket, sock_name: object) -> bool:
+        """Check whether a socket is an INET listener on the configured port."""
+        if sock.family not in (socket.AF_INET, socket.AF_INET6):
+            return False
 
-                if sock_name[1] == self.port:
-                    # Duplicate the socket before returning it
-                    dup_fd = os.dup(fd)
-                    final_sock = socket.fromfd(dup_fd, socket.AF_INET, socket.SOCK_STREAM)
-                    test_sock.close()
+        if not isinstance(sock_name, tuple) or len(sock_name) < 2:
+            return False
+
+        return sock_name[1] == self.port
+
+    def _inspect_socket_fd(self, fd: int) -> tuple[socket.socket, object]:
+        """Duplicate and inspect an inherited socket descriptor."""
+        sock = socket.socket(fileno=os.dup(fd))
+        return sock, sock.getsockname()
+
+    def _process_launchd_sockets(self, socket_fds: list[int]) -> socket.socket:
+        """Process sockets returned directly from launchd."""
+        for fd in socket_fds:
+            test_sock = None
+            try:
+                test_sock, sock_name = self._inspect_socket_fd(fd)
+                logger.info(
+                    f"Found launchd socket on FD {fd}, family={test_sock.family}, bound to {sock_name}"
+                )
+
+                if self._socket_matches_port(test_sock, sock_name):
+                    logger.info(f"Using launchd socket on FD {fd} for port {self.port}")
+                    final_sock = test_sock
+                    test_sock = None
                     return final_sock
-                else:
-                    test_sock.close()
 
             except Exception as e:
                 logger.debug(f"Failed to process FD {fd}: {e}")
-                continue
+            finally:
+                if test_sock is not None:
+                    try:
+                        test_sock.close()
+                    except Exception:
+                        pass
 
         raise VMStartupError("No matching socket found in launchd file descriptors")
 
@@ -133,42 +126,36 @@ class SocketActivation:
         """Limited fallback file descriptor scanning."""
         logger.debug("Falling back to manual file descriptor scanning...")
 
-        # Check environment variables for additional clues
         for env_var in ["LISTEN_FDS", "LISTEN_PID", "LAUNCH_DAEMON_SOCKET_NAME"]:
             value = os.environ.get(env_var)
             if value:
                 logger.debug(f"Found env var {env_var}={value}")
 
-        # Scan standard range for launchd sockets (typically 3-10)
         for fd in range(3, 11):
+            test_sock = None
             try:
                 fd_stat = os.fstat(fd)
                 if not stat.S_ISSOCK(fd_stat.st_mode):
                     continue
 
-                test_sock = socket.fromfd(fd, socket.AF_INET, socket.SOCK_STREAM)
-                try:
-                    sock_name = test_sock.getsockname()
-                    logger.debug(f"FD {fd}: Socket bound to {sock_name}")
+                test_sock, sock_name = self._inspect_socket_fd(fd)
+                logger.debug(
+                    f"FD {fd}: family={test_sock.family} type={test_sock.type} bound to {sock_name}"
+                )
 
-                    if sock_name[1] == self.port:
-                        logger.info(f"Found matching socket on FD {fd}, bound to {sock_name}")
-                        # Duplicate socket before returning
-                        dup_fd = os.dup(fd)
-                        final_sock = socket.fromfd(dup_fd, socket.AF_INET, socket.SOCK_STREAM)
-                        test_sock.close()
-                        return final_sock
-                    else:
-                        test_sock.close()
+                if self._socket_matches_port(test_sock, sock_name):
+                    logger.info(f"Found matching socket on FD {fd}, bound to {sock_name}")
+                    final_sock = test_sock
+                    test_sock = None
+                    return final_sock
 
-                except Exception as e:
-                    logger.debug(f"Failed to get socket info for FD {fd}: {e}")
+            except Exception as e:
+                logger.debug(f"Failed to get socket info for FD {fd}: {e}")
+            finally:
+                if test_sock is not None:
                     try:
                         test_sock.close()
                     except Exception:
                         pass
-
-            except (OSError, Exception):
-                continue
 
         raise VMStartupError(f"No activation socket found on port {self.port}")

--- a/pkgs/vm-runner/src/virby_vm_runner/ssh.py
+++ b/pkgs/vm-runner/src/virby_vm_runner/ssh.py
@@ -4,7 +4,12 @@ import asyncio
 import logging
 from pathlib import Path
 
-from .constants import SSH_KNOWN_HOSTS_FILE_NAME, SSH_USER_PRIVATE_KEY_FILE_NAME, VM_USER
+from .constants import (
+    SSH_KNOWN_HOSTS_FILE_NAME,
+    SSH_USER_PRIVATE_KEY_FILE_NAME,
+    VM_HOST_NAME,
+    VM_USER,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +22,7 @@ class SSHConnectivityTester:
         self.username = username
         self.ssh_key_path = working_dir / SSH_USER_PRIVATE_KEY_FILE_NAME
         self.known_hosts_path = working_dir / SSH_KNOWN_HOSTS_FILE_NAME
+        self.host_key_alias = f"{VM_HOST_NAME}-key"
 
         self._ssh_base_command = [
             "ssh",
@@ -27,9 +33,13 @@ class SSHConnectivityTester:
             "-o",
             "PasswordAuthentication=no",
             "-o",
-            "StrictHostKeyChecking=accept-new",
+            "StrictHostKeyChecking=yes",
             "-o",
             f"UserKnownHostsFile={self.known_hosts_path}",
+            "-o",
+            f"HostKeyAlias={self.host_key_alias}",
+            "-o",
+            "IdentitiesOnly=yes",
             "-p",
             "22",
             "-i",

--- a/pkgs/vm-runner/src/virby_vm_runner/vm_process.py
+++ b/pkgs/vm-runner/src/virby_vm_runner/vm_process.py
@@ -249,9 +249,12 @@ class VMProcess:
             "virtio-balloon",
         ]
 
-        if self.config.debug_enabled:
-            serial_log = self.working_dir / SERIAL_LOG_FILE_NAME
-            cmd.extend(["--device", f"virtio-serial,logFilePath={serial_log}"])
+        # The guest image is configured with `console=hvc0`, so it always needs
+        # a virtio serial console device to boot. Keep a device
+        # present regardless of debug mode so that toggling it does not require rebuilding the image. 
+        # When debug is disabled, discard the console output to /dev/null
+        serial_log = self.working_dir / SERIAL_LOG_FILE_NAME if self.config.debug_enabled else "/dev/null"
+        cmd.extend(["--device", f"virtio-serial,logFilePath={serial_log}"])
 
         if self.config.rosetta_enabled:
             cmd.extend(["--device", "rosetta,mountTag=rosetta"])


### PR DESCRIPTION
Fixes two issues:

  1. SSH user access now consistently uses a different key to prevent openssh from rejecting the key due to too wide permissions, causing the ssh readiness check to always fail if `allowUserSsh` is enabled
  2. launchd socket activation is wired more directly to fix an issue with corrupt file descriptors that I hit

  #### Changes

  - fix SSH key handling for user access
  - run `virby-vm` directly under launchd
  - rewrite socket activation handling in the runner
  - update related module wiring for the user key management
  
Disclosure: please note that I used agentic coding (Codex 5.4) for commit `57c1a0f`, and so tested using various sharedDirectory settings to check for regressions.