### PR TITLE
Add support for using krunkit instead of vfkit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782821651,
+        "narHash": "sha256-D5jO0ME1lA9bDHnd5kVawBwItG/N4oZr3FlXmMzLec8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "e52c192be9d7b2c4bd4aed326c8731b35f8bb75c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,9 @@
             install -Dm444 edk2/KRUN_EFI.silent.fd $out/share/krunkit/KRUN_EFI.silent.fd
           '';
         });
+
+        # FIXME: remove when https://github.com/NixOS/nixpkgs/pull/495633 is merged
+        vmnet-helper = final.callPackage ./pkgs/vmnet-helper { };
       };
 
       packages =

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A {krun|vf}kit-based linux builder for Nix-darwin";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A vfkit-based linux builder for Nix-darwin";
+  description = "A {krun|vf}kit-based linux builder for Nix-darwin";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
@@ -20,7 +20,15 @@
       ];
 
       forSystem = lib.genAttrs systems (
-        system: (f: { ${system} = f (import nixpkgs { inherit system; }); })
+        system:
+        (f: {
+          ${system} = f (
+            import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            }
+          );
+        })
       );
     in
 
@@ -30,25 +38,37 @@
         virby = import ./module { inherit _lib self; };
       };
 
-      packages =
-        forSystem.aarch64-darwin (pkgs: {
-          default = self.packages.${pkgs.stdenv.hostPlatform.system}.vm-runner;
-          vm-runner = pkgs.callPackage ./pkgs/vm-runner { };
-        })
-        // forSystem.aarch64-linux (pkgs: {
-          default = self.packages.${pkgs.stdenv.hostPlatform.system}.vm-image;
-          vm-image = pkgs.callPackage ./pkgs/vm-image { inherit _lib inputs lib; };
-        });
-
       devShells = forSystem.aarch64-darwin (pkgs: {
         default = pkgs.mkShellNoCC {
           name = "virby-dev";
-          packages = [ pkgs.vfkit ];
+          packages = with pkgs; [
+            krunkit
+            vfkit
+          ];
         };
       });
 
       formatter = forSystem.aarch64-darwin (
         pkgs: pkgs.nixfmt-tree.override { settings.formatter.nixfmt.options = [ "--strict" ]; }
       );
+
+      overlays.default = final: prev: {
+        # FIXME: remove when https://github.com/NixOS/nixpkgs/pull/525378 is merged
+        krunkit = prev.krunkit.overrideAttrs (old: {
+          postInstall = (prev.postInstall or "") + ''
+            install -Dm444 edk2/KRUN_EFI.silent.fd $out/share/krunkit/KRUN_EFI.silent.fd
+          '';
+        });
+      };
+
+      packages =
+        forSystem.aarch64-darwin (pkgs: {
+          default = self.packages.${darwinSystem}.vm-runner;
+          vm-runner = pkgs.callPackage ./pkgs/vm-runner { };
+        })
+        // forSystem.aarch64-linux (pkgs: {
+          default = self.packages.${linuxSystem}.vm-image;
+          vm-image = pkgs.callPackage ./pkgs/vm-image { inherit _lib inputs lib; };
+        });
     };
 }

--- a/module/default.nix
+++ b/module/default.nix
@@ -75,12 +75,14 @@ let
     builtins.toJSON {
       cores = cfg.cores;
       debug = cfg.debug;
+      driver = cfg.driver;
+      driver-package = cfg.driverPackage;
       memory = parseMemoryMiB cfg.memory;
       on-demand = cfg.onDemand.enable;
       port = cfg.port;
       rosetta = cfg.rosetta;
-      ttl = cfg.onDemand.ttl * 60; # Convert to seconds
       shared-dirs = cfg.sharedDirectories;
+      ttl = cfg.onDemand.ttl * 60;
     }
   );
 
@@ -238,6 +240,9 @@ in
   imports = [ ./options.nix ];
 
   config = lib.mkMerge [
+    # FIXME: remove when https://github.com/NixOS/nixpkgs/pull/525378 is merged
+    (lib.mkIf (cfg.driver == "krunkit") { nixpkgs.overlays = [ self.overlays.default ]; })
+
     (lib.mkIf (!cfg.enable) {
       system.activationScripts.postActivation.text = lib.mkBefore ''
         ${setupLogFunctions}

--- a/module/default.nix
+++ b/module/default.nix
@@ -76,13 +76,14 @@ let
       cores = cfg.cores;
       debug = cfg.debug;
       driver = cfg.driver;
-      driver-package = cfg.driverPackage;
+      driver-bin = lib.getExe cfg.driverPackage;
       memory = parseMemoryMiB cfg.memory;
       on-demand = cfg.onDemand.enable;
       port = cfg.port;
       rosetta = cfg.rosetta;
       shared-dirs = cfg.sharedDirectories;
       ttl = cfg.onDemand.ttl * 60;
+      vmnet-helper-bin = lib.optionalString (cfg.driver == "krunkit") (lib.getExe pkgs.vmnet-helper);
     }
   );
 

--- a/module/default.nix
+++ b/module/default.nix
@@ -383,12 +383,7 @@ in
       system.build.virbyImage = imageWithFinalConfig;
     })
 
-    (lib.mkIf (!cfg.supportDeterminateNix) {
-      nix = {
-        inherit buildMachines distributedBuilds;
-        settings.builders-use-substitutes = lib.mkDefault true;
-      };
-    })
+    (lib.mkIf (!cfg.supportDeterminateNix) { nix = { inherit buildMachines distributedBuilds; }; })
 
     (lib.mkIf cfg.supportDeterminateNix (
       {
@@ -407,10 +402,7 @@ in
         ];
       }
       // lib.optionalAttrs (options ? determinateNix) {
-        determinateNix = {
-          inherit buildMachines distributedBuilds;
-          customSettings.builders-use-substitutes = lib.mkDefault true;
-        };
+        determinateNix = { inherit buildMachines distributedBuilds; };
       }
     ))
   ];

--- a/module/options.nix
+++ b/module/options.nix
@@ -37,18 +37,6 @@
       '';
     };
 
-    supportDeterminateNix = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Whether to enable support for using Virby with Determinate Nix.
-
-        When enabled, the config will set `determinateNix.buildMachines` instead of
-        `nix.buildMachines`. This requires that the Determinate module for Nix-darwin is already
-        imported in your configuration and will throw an error otherwise.
-      '';
-    };
-
     diskSize = lib.mkOption {
       type = lib.types.str;
       default = "100GiB";
@@ -170,6 +158,18 @@
 
         This is an arbitrary integer that indicates the speed of this builder, relative to other
         builders. Higher is faster.
+      '';
+    };
+
+    supportDeterminateNix = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable support for using Virby with Determinate Nix.
+
+        When enabled, the config will set `determinateNix.buildMachines` instead of
+        `nix.buildMachines`. This requires that the Determinate module for Nix-darwin is already
+        imported in your configuration and will throw an error otherwise.
       '';
     };
   };

--- a/module/options.nix
+++ b/module/options.nix
@@ -1,4 +1,13 @@
-{ lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.virby;
+in
 
 {
   options.services.virby = {
@@ -44,6 +53,30 @@
         The size of the disk image for the VM.
 
         The option value must be a string with a number, followed by the suffix "GiB".
+      '';
+    };
+
+    driver = lib.mkOption {
+      type = lib.types.enum [
+        "krunkit"
+        "vfkit"
+      ];
+      default = "vfkit";
+      description = ''
+        The virtualization driver used to run the VM.
+
+        Must be either "krunkit" or "vfkit".
+      '';
+    };
+
+    driverPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      default = pkgs.${cfg.driver};
+      description = ''
+        Read-only option exposing the virtualization driver package.
+
+        To specify which driver to use for the VM, use the `services.virby.driver` option instead.
       '';
     };
 

--- a/pkgs/vm-runner/default.nix
+++ b/pkgs/vm-runner/default.nix
@@ -1,8 +1,4 @@
-{
-  buildGoModule,
-  lib,
-  vfkit,
-}:
+{ buildGoModule, lib }:
 
 buildGoModule {
   name = "virby-vm-runner";
@@ -10,10 +6,8 @@ buildGoModule {
 
   vendorHash = "sha256-Ivlyju4bHiKAfCKAYUmmoQzChD6o1kHE7dSrFwz7aDU=";
 
-  ldflags = [ "-X vm-runner/internal/vmprocess.vfkitBin=${lib.getExe vfkit}" ];
-
   meta = {
-    description = "Vfkit-based VM runner for Virby";
+    description = "VM runner for Virby";
     homepage = "https://github.com/quinneden/virby-nix-darwin";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;

--- a/pkgs/vm-runner/internal/api/api.go
+++ b/pkgs/vm-runner/internal/api/api.go
@@ -27,9 +27,9 @@ const (
 )
 
 type APIClient struct {
-	port           int
-	isRunningCheck func() bool
 	client         *http.Client
+	isRunningCheck func() bool
+	port           int
 }
 
 func NewAPIClient(port int, isRunningCheck func() bool) *APIClient {
@@ -42,9 +42,9 @@ func NewAPIClient(port int, isRunningCheck func() bool) *APIClient {
 	}
 
 	return &APIClient{
-		port:           port,
-		isRunningCheck: isRunningCheck,
 		client:         client,
+		isRunningCheck: isRunningCheck,
+		port:           port,
 	}
 }
 
@@ -99,6 +99,9 @@ func (c *APIClient) callAPI(endpoint string, method string, data Data) (Data, er
 		if err != nil || len(respBody) == 0 {
 			return nil, nil
 		}
+
+		// krunkit appends a null byte to the JSON response
+		respBody = bytes.TrimRight(respBody, "\x00")
 
 		var result Data
 		if err := json.Unmarshal(respBody, &result); err != nil {

--- a/pkgs/vm-runner/internal/api/api.go
+++ b/pkgs/vm-runner/internal/api/api.go
@@ -26,13 +26,13 @@ const (
 	VMStateStopping  VMState = "VirtualMachineStateStopping"
 )
 
-type VfkitAPIClient struct {
+type APIClient struct {
 	port           int
 	isRunningCheck func() bool
 	client         *http.Client
 }
 
-func NewVfkitAPIClient(port int, isRunningCheck func() bool) *VfkitAPIClient {
+func NewAPIClient(port int, isRunningCheck func() bool) *APIClient {
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
@@ -41,14 +41,14 @@ func NewVfkitAPIClient(port int, isRunningCheck func() bool) *VfkitAPIClient {
 		},
 	}
 
-	return &VfkitAPIClient{
+	return &APIClient{
 		port:           port,
 		isRunningCheck: isRunningCheck,
 		client:         client,
 	}
 }
 
-func (c *VfkitAPIClient) callAPI(endpoint string, method string, data Data) (Data, error) {
+func (c *APIClient) callAPI(endpoint string, method string, data Data) (Data, error) {
 	if c.isRunningCheck != nil && !c.isRunningCheck() {
 		return nil, fmt.Errorf("the virtual machine is not running")
 	}
@@ -110,15 +110,15 @@ func (c *VfkitAPIClient) callAPI(endpoint string, method string, data Data) (Dat
 	return nil, fmt.Errorf("request failed after %d attempts", maxRetries+1)
 }
 
-func (c *VfkitAPIClient) Close() {
+func (c *APIClient) Close() {
 	c.client.CloseIdleConnections()
 	c.client = nil
 }
 
-func (c *VfkitAPIClient) Get(endpoint string) (Data, error) {
+func (c *APIClient) Get(endpoint string) (Data, error) {
 	return c.callAPI(endpoint, "GET", nil)
 }
 
-func (c *VfkitAPIClient) Post(endpoint string, data Data) (Data, error) {
+func (c *APIClient) Post(endpoint string, data Data) (Data, error) {
 	return c.callAPI(endpoint, "POST", data)
 }

--- a/pkgs/vm-runner/internal/config/config.go
+++ b/pkgs/vm-runner/internal/config/config.go
@@ -8,19 +8,23 @@ import (
 )
 
 type vmConfigJSON struct {
-	Cores      int               `json:"cores"`
-	Debug      bool              `json:"debug"`
-	Memory     int               `json:"memory"`
-	OnDemand   bool              `json:"on-demand"`
-	Port       int               `json:"port"`
-	Rosetta    bool              `json:"rosetta"`
-	SharedDirs map[string]string `json:"shared-dirs"`
-	TTL        int               `json:"ttl"`
+	Cores         int               `json:"cores"`
+	Debug         bool              `json:"debug"`
+	Driver        string            `json:"driver"`
+	DriverPackage string            `json:"driver-package"`
+	Memory        int               `json:"memory"`
+	OnDemand      bool              `json:"on-demand"`
+	Port          int               `json:"port"`
+	Rosetta       bool              `json:"rosetta"`
+	SharedDirs    map[string]string `json:"shared-dirs"`
+	TTL           int               `json:"ttl"`
 }
 
 type VMConfig struct {
 	Cores            int
 	Debug            bool
+	Driver           string
+	DriverPackage    string
 	Memory           int
 	OnDemand         bool
 	Port             int
@@ -98,6 +102,8 @@ func NewVMConfig(configFilePath string) (*VMConfig, error) {
 	return &VMConfig{
 		Cores:            raw.Cores,
 		Debug:            raw.Debug,
+		Driver:           raw.Driver,
+		DriverPackage:    raw.DriverPackage,
 		Memory:           raw.Memory,
 		OnDemand:         raw.OnDemand,
 		Port:             raw.Port,

--- a/pkgs/vm-runner/internal/config/config.go
+++ b/pkgs/vm-runner/internal/config/config.go
@@ -8,29 +8,31 @@ import (
 )
 
 type vmConfigJSON struct {
-	Cores         int               `json:"cores"`
-	Debug         bool              `json:"debug"`
-	Driver        string            `json:"driver"`
-	DriverPackage string            `json:"driver-package"`
-	Memory        int               `json:"memory"`
-	OnDemand      bool              `json:"on-demand"`
-	Port          int               `json:"port"`
-	Rosetta       bool              `json:"rosetta"`
-	SharedDirs    map[string]string `json:"shared-dirs"`
-	TTL           int               `json:"ttl"`
+	Cores          int               `json:"cores"`
+	Debug          bool              `json:"debug"`
+	Driver         string            `json:"driver"`
+	DriverBin      string            `json:"driver-bin"`
+	Memory         int               `json:"memory"`
+	OnDemand       bool              `json:"on-demand"`
+	Port           int               `json:"port"`
+	Rosetta        bool              `json:"rosetta"`
+	SharedDirs     map[string]string `json:"shared-dirs"`
+	TTL            int               `json:"ttl"`
+	VMNetHelperBin string            `json:"vmnet-helper-bin"`
 }
 
 type VMConfig struct {
 	Cores            int
 	Debug            bool
 	Driver           string
-	DriverPackage    string
+	DriverBin        string
 	Memory           int
 	OnDemand         bool
 	Port             int
 	Rosetta          bool
 	SharedDirs       map[string]string
 	TTL              int
+	VMNetHelperBin   string
 	WorkingDirectory string
 }
 
@@ -56,6 +58,13 @@ func NewVMConfig(configFilePath string) (*VMConfig, error) {
 		return nil, fmt.Errorf("invalid value for 'port': %v", raw.Port)
 	}
 
+	if _, err := os.Stat(raw.DriverBin); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("path not found: %s", raw.DriverBin)
+		}
+		return nil, fmt.Errorf("could not access path: %w", err)
+	}
+
 	resolvedSharedDirs := make(map[string]string)
 
 	for tag, path := range raw.SharedDirs {
@@ -76,6 +85,15 @@ func NewVMConfig(configFilePath string) (*VMConfig, error) {
 		}
 
 		resolvedSharedDirs[tag] = absPath
+	}
+
+	if raw.Driver == DriverKrunkit {
+		if _, err := os.Stat(raw.VMNetHelperBin); err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("path not found: %s", raw.VMNetHelperBin)
+			}
+			return nil, fmt.Errorf("could not access path: %w", err)
+		}
 	}
 
 	workingDirectory := os.Getenv("VIRBY_WORKING_DIRECTORY")
@@ -103,13 +121,14 @@ func NewVMConfig(configFilePath string) (*VMConfig, error) {
 		Cores:            raw.Cores,
 		Debug:            raw.Debug,
 		Driver:           raw.Driver,
-		DriverPackage:    raw.DriverPackage,
+		DriverBin:        raw.DriverBin,
 		Memory:           raw.Memory,
 		OnDemand:         raw.OnDemand,
 		Port:             raw.Port,
 		Rosetta:          raw.Rosetta,
 		SharedDirs:       resolvedSharedDirs,
 		TTL:              raw.TTL,
+		VMNetHelperBin:   raw.VMNetHelperBin,
 		WorkingDirectory: workingDirectoryAbs,
 	}, nil
 }

--- a/pkgs/vm-runner/internal/config/constants.go
+++ b/pkgs/vm-runner/internal/config/constants.go
@@ -1,6 +1,7 @@
 package config
 
 const (
+	DriverKrunkit           = "krunkit"
 	IPDiscoveryTimeout      = 60
 	SSHReadyTimeout         = 30
 	VMPauseTimeout          = 30

--- a/pkgs/vm-runner/internal/runner/runner.go
+++ b/pkgs/vm-runner/internal/runner/runner.go
@@ -70,9 +70,7 @@ func (r *Runner) scheduleShutdownCheck(ctx context.Context) error {
 					return err
 				}
 			} else {
-				if err := r.vmProcess.Stop(30 * time.Second); err != nil {
-					return err
-				}
+				r.vmProcess.Stop(30 * time.Second)
 			}
 		}
 		return nil

--- a/pkgs/vm-runner/internal/vmnethelper/vmnethelper.go
+++ b/pkgs/vm-runner/internal/vmnethelper/vmnethelper.go
@@ -1,0 +1,147 @@
+package vmnethelper
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+type VMNetHelper struct {
+	command        *exec.Cmd
+	exitCh         chan struct{}
+	mu             sync.Mutex
+	stopRequested  atomic.Bool
+	vmnetHelperBin string
+}
+
+func NewVMNetHelper(vmnetHelperBin string) *VMNetHelper {
+	return &VMNetHelper{vmnetHelperBin: vmnetHelperBin}
+}
+
+func (h *VMNetHelper) createSocketpair() (*os.File, *os.File, error) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_DGRAM, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create socketpair: %w", err)
+	}
+
+	bufSize := 256 * 1024
+	for _, fd := range fds {
+		if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF, bufSize); err != nil {
+			return nil, nil, fmt.Errorf("failed to set SO_SNDBUF: %w", err)
+		}
+		if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, bufSize); err != nil {
+			return nil, nil, fmt.Errorf("failed to set SO_RCVBUF: %w", err)
+		}
+	}
+
+	helperFD := os.NewFile(uintptr(fds[0]), "vmnet-helper-fd")
+	driverFD := os.NewFile(uintptr(fds[1]), "vm-driver-fd")
+
+	return helperFD, driverFD, nil
+}
+
+func (h *VMNetHelper) Start() (*os.File, error) {
+	helperFD, driverFD, err := h.createSocketpair()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{"--fd", "3", "--enable-checksum-offload", "--enable-tso"}
+
+	cmd := exec.Command(h.vmnetHelperBin, args...)
+	cmd.ExtraFiles = []*os.File{helperFD}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		driverFD.Close()
+		helperFD.Close()
+		return nil, err
+	}
+
+	slog.Info("starting vmnet-helper")
+	h.stopRequested.Store(false)
+
+	if err := cmd.Start(); err != nil {
+		driverFD.Close()
+		helperFD.Close()
+		return nil, fmt.Errorf("failed to execute command: %w", err)
+	}
+
+	helperFD.Close()
+
+	h.mu.Lock()
+	h.command = cmd
+	h.exitCh = make(chan struct{})
+	h.mu.Unlock()
+
+	go h.monitor()
+
+	if err := json.NewDecoder(stdout).Decode(&json.RawMessage{}); err != nil {
+		cmd.Process.Kill()
+		<-h.exitCh
+		driverFD.Close()
+
+		return nil, fmt.Errorf("failed to decode vmnet-helper JSON output: %w", err)
+	}
+
+	return driverFD, nil
+}
+
+func (h *VMNetHelper) monitor() {
+	h.mu.Lock()
+	cmd := h.command
+	h.mu.Unlock()
+
+	if cmd == nil {
+		return
+	}
+
+	err := cmd.Wait()
+
+	h.mu.Lock()
+	exitCh := h.exitCh
+	h.mu.Unlock()
+
+	if exitCh != nil {
+		close(exitCh)
+	}
+
+	if err != nil && !h.stopRequested.Load() {
+		slog.Error("vmnet-helper process failed", "error", err)
+	}
+}
+
+func (h *VMNetHelper) Stop(timeout time.Duration) {
+	slog.Info("stopping vmnet-helper")
+
+	h.stopRequested.Store(true)
+
+	h.mu.Lock()
+	cmd := h.command
+	exitCh := h.exitCh
+	h.mu.Unlock()
+
+	if cmd != nil && exitCh != nil {
+		cmd.Process.Signal(syscall.SIGTERM)
+
+		select {
+		case <-exitCh:
+			slog.Info("vmnet-helper stopped gracefully")
+		case <-time.After(timeout):
+			slog.Info("unable to stop vmnet-helper gracefully, killing process instead", "reason", "timeout exceeded")
+			cmd.Process.Kill()
+			<-exitCh
+		}
+	}
+
+	h.mu.Lock()
+	h.command = nil
+	h.exitCh = nil
+	h.mu.Unlock()
+}

--- a/pkgs/vm-runner/internal/vmprocess/vmprocess.go
+++ b/pkgs/vm-runner/internal/vmprocess/vmprocess.go
@@ -22,6 +22,7 @@ import (
 	"vm-runner/internal/config"
 	"vm-runner/internal/ipdiscovery"
 	"vm-runner/internal/ssh"
+	"vm-runner/internal/vmnethelper"
 )
 
 type VMProcessState string
@@ -33,12 +34,11 @@ const (
 	VMProcessStateUnknown VMProcessState = "unknown"
 )
 
-var vfkitBin = "vfkit"
-
 type VMProcess struct {
 	apiClient         *api.APIClient
 	apiPort           int
 	circuitBreaker    *circuitbreaker.CircuitBreaker
+	command           *exec.Cmd
 	config            *config.VMConfig
 	ipAddress         string
 	ipDiscovery       *ipdiscovery.IPDiscovery
@@ -48,7 +48,7 @@ type VMProcess struct {
 	pidFile           string
 	processExitCh     chan struct{}
 	shutdownRequested atomic.Bool
-	command           *exec.Cmd
+	vmnetHelper       *vmnethelper.VMNetHelper
 }
 
 func generateMacAddress() string {
@@ -82,20 +82,24 @@ func consumeVMProcessOutput(stdout, stderr io.ReadCloser, ch chan struct{}) {
 	wg.Wait()
 }
 
-func NewVMProcess(config *config.VMConfig) *VMProcess {
-	apiPort := config.Port + 1
+func NewVMProcess(cfg *config.VMConfig) *VMProcess {
+	apiPort := cfg.Port + 1
 	macAddress := generateMacAddress()
 
 	vp := &VMProcess{
 		apiPort:        apiPort,
 		circuitBreaker: circuitbreaker.NewCircuitBreaker(3, 10*time.Second),
-		config:         config,
+		config:         cfg,
 		ipDiscovery:    ipdiscovery.NewIPDiscovery(macAddress, ""),
 		macAddress:     macAddress,
-		pidFile:        filepath.Join(config.WorkingDirectory, "vfkit.pid"),
+		pidFile:        filepath.Join(cfg.WorkingDirectory, "vm.pid"),
 	}
 
 	vp.apiClient = api.NewAPIClient(apiPort, vp.IsRunning)
+
+	if vp.config.Driver == config.DriverKrunkit {
+		vp.vmnetHelper = vmnethelper.NewVMNetHelper(vp.config.VMNetHelperBin)
+	}
 
 	return vp
 }
@@ -112,7 +116,7 @@ func (vp *VMProcess) IPAddress() string {
 	return vp.ipAddress
 }
 
-func (vp *VMProcess) buildVfkitCommand() []string {
+func (vp *VMProcess) buildDriverCommand() []string {
 	diffDiskPath := filepath.Join(vp.config.WorkingDirectory, diffDiskFileName)
 	efiStorePath := filepath.Join(vp.config.WorkingDirectory, efiVariableStoreFileName)
 	serialLogFilePath := "/dev/null"
@@ -123,27 +127,26 @@ func (vp *VMProcess) buildVfkitCommand() []string {
 	}
 
 	cmd := []string{
-		vfkitBin,
-		"--cpus",
-		fmt.Sprintf("%d", vp.config.Cores),
-		"--memory",
-		fmt.Sprintf("%d", vp.config.Memory),
-		"--bootloader",
-		fmt.Sprintf("efi,variable-store=%s,create", efiStorePath),
-		"--device",
-		fmt.Sprintf("virtio-blk,path=%s", diffDiskPath),
-		"--device",
-		fmt.Sprintf("virtio-fs,sharedDir=%s,mountTag=sshd-keys", sshdKeysDirPath),
-		"--device",
-		fmt.Sprintf("virtio-net,nat,mac=%s", vp.macAddress),
-		"--device",
-		fmt.Sprintf("virtio-serial,logFilePath=%s", serialLogFilePath),
-		"--restful-uri",
-		fmt.Sprintf("tcp://localhost:%d", vp.apiPort),
-		"--device",
-		"virtio-rng",
-		"--device",
-		"virtio-balloon",
+		vp.config.DriverBin,
+		"--cpus", fmt.Sprintf("%d", vp.config.Cores),
+		"--memory", fmt.Sprintf("%d", vp.config.Memory),
+		"--bootloader", fmt.Sprintf("efi,variable-store=%s,create", efiStorePath),
+		"--device", fmt.Sprintf("virtio-blk,path=%s", diffDiskPath),
+		"--device", fmt.Sprintf("virtio-fs,sharedDir=%s,mountTag=sshd-keys", sshdKeysDirPath),
+		"--device", fmt.Sprintf("virtio-serial,logFilePath=%s", serialLogFilePath),
+		"--restful-uri", fmt.Sprintf("tcp://localhost:%d", vp.apiPort),
+		"--device", "virtio-rng",
+	}
+
+	if vp.vmnetHelper != nil {
+		cmd = append(cmd,
+			"--device", fmt.Sprintf("virtio-net,type=unixgram,fd=3,mac=%s,offloading=on", vp.macAddress),
+		)
+	} else {
+		cmd = append(cmd,
+			"--device", fmt.Sprintf("virtio-net,nat,mac=%s", vp.macAddress),
+			"--device", "virtio-balloon",
+		)
 	}
 
 	if vp.config.Rosetta {
@@ -288,7 +291,7 @@ func (vp *VMProcess) removePIDFile() error {
 }
 
 func (vp *VMProcess) writePIDFile() error {
-	tmpFile, err := os.CreateTemp(vp.config.WorkingDirectory, "vfkit.pid.*")
+	tmpFile, err := os.CreateTemp(vp.config.WorkingDirectory, "vm.pid.*")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary PID file: %w", err)
 	}
@@ -324,8 +327,8 @@ func (vp *VMProcess) startVMProcess() error {
 		return fmt.Errorf("VM process is already running")
 	}
 
-	vfkitCommand := vp.buildVfkitCommand()
-	cmd := exec.Command(vfkitCommand[0], vfkitCommand[1:]...)
+	driverCommand := vp.buildDriverCommand()
+	cmd := exec.Command(driverCommand[0], driverCommand[1:]...)
 	cmd.Dir = vp.config.WorkingDirectory
 
 	var stdout, stderr io.ReadCloser
@@ -346,8 +349,27 @@ func (vp *VMProcess) startVMProcess() error {
 		cmd.Stderr = io.Discard
 	}
 
+	var fd *os.File
+	if vp.vmnetHelper != nil {
+		var err error
+		fd, err = vp.vmnetHelper.Start()
+		if err != nil {
+			return err
+		}
+
+		cmd.ExtraFiles = []*os.File{fd}
+	}
+
 	if err := cmd.Start(); err != nil {
+		if vp.vmnetHelper != nil {
+			fd.Close()
+			vp.vmnetHelper.Stop(10 * time.Second)
+		}
 		return fmt.Errorf("failed to execute command: %w", err)
+	}
+
+	if vp.vmnetHelper != nil {
+		fd.Close()
 	}
 
 	vp.mu.Lock()
@@ -403,6 +425,9 @@ func (vp *VMProcess) monitorVM() {
 	}
 
 	if !vp.shutdownRequested.Load() {
+		if vp.vmnetHelper != nil {
+			vp.vmnetHelper.Stop(10 * time.Second)
+		}
 		vp.resetVMProcessState()
 	}
 }
@@ -495,8 +520,8 @@ func (vp *VMProcess) Start() error {
 
 	vp.shutdownRequested.Store(false)
 
-	if err := vp.killOrphanedVfkitProcesses(); err != nil {
-		slog.Error("failed to kill orphaned vfkit process", "error", err)
+	if err := vp.killOrphanedDriverProcesses(); err != nil {
+		slog.Error(fmt.Sprintf("failed to kill orphaned %s process", vp.config.Driver), "error", err)
 	}
 	if err := vp.startVMProcess(); err != nil {
 		return err
@@ -520,7 +545,7 @@ func (vp *VMProcess) Start() error {
 	return nil
 }
 
-func (vp *VMProcess) Stop(timeout time.Duration) error {
+func (vp *VMProcess) Stop(timeout time.Duration) {
 	slog.Info("stopping the VM")
 
 	vp.shutdownRequested.Store(true)
@@ -541,10 +566,13 @@ func (vp *VMProcess) Stop(timeout time.Duration) error {
 			cmd.Process.Kill()
 			<-exitCh
 		}
+
+		if vp.vmnetHelper != nil {
+			vp.vmnetHelper.Stop(10 * time.Second)
+		}
 	}
 
 	vp.resetVMProcessState()
-	return nil
 }
 
 func (vp *VMProcess) Pause() error {
@@ -594,9 +622,7 @@ func (vp *VMProcess) PauseOrStop() error {
 	slog.Info("VM cannot be paused, stopping instead")
 
 	stopTimeout := 30 * time.Second
-	if err := vp.Stop(stopTimeout); err != nil {
-		return err
-	}
+	vp.Stop(stopTimeout)
 
 	return nil
 }
@@ -612,17 +638,13 @@ func (vp *VMProcess) ResumeOrStart() error {
 		if err := vp.Resume(); err == nil {
 			return nil
 		}
-		if err := vp.Stop(30 * time.Second); err != nil {
-			return err
-		}
+		vp.Stop(30 * time.Second)
 
 	case VMProcessStateStopped:
 		break
 
 	case VMProcessStateUnknown:
-		if err := vp.Stop(30 * time.Second); err != nil {
-			return err
-		}
+		vp.Stop(30 * time.Second)
 	}
 
 	if err := vp.Start(); err != nil {
@@ -632,7 +654,7 @@ func (vp *VMProcess) ResumeOrStart() error {
 	return nil
 }
 
-func (vp *VMProcess) killOrphanedVfkitProcesses() error {
+func (vp *VMProcess) killOrphanedDriverProcesses() error {
 	content, err := os.ReadFile(vp.pidFile)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkgs/vm-runner/internal/vmprocess/vmprocess.go
+++ b/pkgs/vm-runner/internal/vmprocess/vmprocess.go
@@ -36,7 +36,7 @@ const (
 var vfkitBin = "vfkit"
 
 type VMProcess struct {
-	apiClient         *api.VfkitAPIClient
+	apiClient         *api.APIClient
 	apiPort           int
 	circuitBreaker    *circuitbreaker.CircuitBreaker
 	config            *config.VMConfig
@@ -95,7 +95,7 @@ func NewVMProcess(config *config.VMConfig) *VMProcess {
 		pidFile:        filepath.Join(config.WorkingDirectory, "vfkit.pid"),
 	}
 
-	vp.apiClient = api.NewVfkitAPIClient(apiPort, vp.IsRunning)
+	vp.apiClient = api.NewAPIClient(apiPort, vp.IsRunning)
 
 	return vp
 }

--- a/pkgs/vmnet-helper/default.nix
+++ b/pkgs/vmnet-helper/default.nix
@@ -1,0 +1,54 @@
+# FIXME: delete this file when https://github.com/NixOS/nixpkgs/pull/495633 is merged
+{
+  darwin,
+  fetchFromGitHub,
+  gitMinimal,
+  lib,
+  meson,
+  ninja,
+  nix-update-script,
+  python3,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vmnet-helper";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "nirs";
+    repo = "vmnet-helper";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pqkikynl5QzcPwKP3KdloZ6W5F8EfZW6arpL5jQOR9w=";
+  };
+
+  nativeBuildInputs = [
+    darwin.sigtool
+    gitMinimal
+    meson
+    ninja
+    (python3.withPackages (
+      ps: with ps; [
+        pyyaml
+        scapy
+      ]
+    ))
+  ];
+
+  postFixup = ''
+    codesign -f --entitlements $src/building/entitlements.plist -s - $out/bin/vmnet-helper
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "High-performance network proxy connecting VMs to macOS vmnet";
+    mainProgram = "vmnet-helper";
+    homepage = "https://github.com/nirs/vmnet-helper";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
### Summary

This PR introduces support for using `krunkit` as an alternative virtualization driver to `vfkit`. It introduces new module configurations for driver selection, adds temporary overlays for missing upstream dependencies, and refactors the Go-based `vm-runner` to handle multiple virtualization backends.

### Key Changes

* **New Driver Configuration:** * Added `services.virby.driver` option (accepts `"vfkit"` or `"krunkit"`, defaulting to `"vfkit"`).
* Added a read-only `services.virby.driverPackage` option.

* **VM Runner Refactor:**
* Generalized `VfkitAPIClient` to `APIClient` and updated the PID file naming from `vfkit.pid` to `vm.pid`.
* Added a `vmnethelper` Go package to handle socket creation and lifecycle management for `vmnet-helper`.
* The runner now dynamically builds the execution command and configures `virtio-net` differently based on the selected driver.


* **Flake & Nixpkgs Maintenance:**
* Track `nixpkgs-unstable` instead of `nixos-unstable`.
* Added a derivation for `vmnet-helper` (until https://github.com/NixOS/nixpkgs/pull/495633 is merged).
* Added temporary override for `krunkit` (until https://github.com/NixOS/nixpkgs/pull/525378 is merged).
* Added `krunkit` to the default `devShell`.