### PR TITLE
feat: add support for nested virtualization (fixes #21)

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -78,6 +78,7 @@ let
       driver = cfg.driver;
       driver-bin = lib.getExe cfg.driverPackage;
       memory = parseMemoryMiB cfg.memory;
+      nested-virtualization = cfg.nestedVirtualization;
       on-demand = cfg.onDemand.enable;
       port = cfg.port;
       rosetta = cfg.rosetta;

--- a/module/options.nix
+++ b/module/options.nix
@@ -111,6 +111,18 @@ in
       '';
     };
 
+    nestedVirtualization = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable nested virtualization for the driver.
+
+        Nested virtualization requires an M3 or later CPU and macOS 15+. Since Nix lacks the ability to
+        check the CPU version, the vm-runner will check at runtime. If the CPU is not compatible, vm-runner
+        will print a warning in the log file and ignore the option.
+      '';
+    };
+
     onDemand = lib.mkOption {
       type =
         with lib.types;

--- a/pkgs/vm-runner/internal/config/config.go
+++ b/pkgs/vm-runner/internal/config/config.go
@@ -8,32 +8,34 @@ import (
 )
 
 type vmConfigJSON struct {
-	Cores          int               `json:"cores"`
-	Debug          bool              `json:"debug"`
-	Driver         string            `json:"driver"`
-	DriverBin      string            `json:"driver-bin"`
-	Memory         int               `json:"memory"`
-	OnDemand       bool              `json:"on-demand"`
-	Port           int               `json:"port"`
-	Rosetta        bool              `json:"rosetta"`
-	SharedDirs     map[string]string `json:"shared-dirs"`
-	TTL            int               `json:"ttl"`
-	VMNetHelperBin string            `json:"vmnet-helper-bin"`
+	Cores                int               `json:"cores"`
+	Debug                bool              `json:"debug"`
+	Driver               string            `json:"driver"`
+	DriverBin            string            `json:"driver-bin"`
+	Memory               int               `json:"memory"`
+	NestedVirtualization bool              `json:"nested-virtualization"`
+	OnDemand             bool              `json:"on-demand"`
+	Port                 int               `json:"port"`
+	Rosetta              bool              `json:"rosetta"`
+	SharedDirs           map[string]string `json:"shared-dirs"`
+	TTL                  int               `json:"ttl"`
+	VMNetHelperBin       string            `json:"vmnet-helper-bin"`
 }
 
 type VMConfig struct {
-	Cores            int
-	Debug            bool
-	Driver           string
-	DriverBin        string
-	Memory           int
-	OnDemand         bool
-	Port             int
-	Rosetta          bool
-	SharedDirs       map[string]string
-	TTL              int
-	VMNetHelperBin   string
-	WorkingDirectory string
+	Cores                int
+	Debug                bool
+	Driver               string
+	DriverBin            string
+	Memory               int
+	NestedVirtualization bool
+	OnDemand             bool
+	Port                 int
+	Rosetta              bool
+	SharedDirs           map[string]string
+	TTL                  int
+	VMNetHelperBin       string
+	WorkingDirectory     string
 }
 
 func NewVMConfig(configFilePath string) (*VMConfig, error) {
@@ -118,17 +120,18 @@ func NewVMConfig(configFilePath string) (*VMConfig, error) {
 	}
 
 	return &VMConfig{
-		Cores:            raw.Cores,
-		Debug:            raw.Debug,
-		Driver:           raw.Driver,
-		DriverBin:        raw.DriverBin,
-		Memory:           raw.Memory,
-		OnDemand:         raw.OnDemand,
-		Port:             raw.Port,
-		Rosetta:          raw.Rosetta,
-		SharedDirs:       resolvedSharedDirs,
-		TTL:              raw.TTL,
-		VMNetHelperBin:   raw.VMNetHelperBin,
-		WorkingDirectory: workingDirectoryAbs,
+		Cores:                raw.Cores,
+		Debug:                raw.Debug,
+		Driver:               raw.Driver,
+		DriverBin:            raw.DriverBin,
+		Memory:               raw.Memory,
+		NestedVirtualization: raw.NestedVirtualization,
+		OnDemand:             raw.OnDemand,
+		Port:                 raw.Port,
+		Rosetta:              raw.Rosetta,
+		SharedDirs:           resolvedSharedDirs,
+		TTL:                  raw.TTL,
+		VMNetHelperBin:       raw.VMNetHelperBin,
+		WorkingDirectory:     workingDirectoryAbs,
 	}, nil
 }

--- a/pkgs/vm-runner/internal/vm_process/vm_process.go
+++ b/pkgs/vm-runner/internal/vm_process/vm_process.go
@@ -116,7 +116,7 @@ func (vp *VMProcess) IPAddress() string {
 	return vp.ipAddress
 }
 
-func (vp *VMProcess) buildDriverCommand() []string {
+func (vp *VMProcess) buildDriverCommand() ([]string, error) {
 	diffDiskPath := filepath.Join(vp.config.WorkingDirectory, diffDiskFileName)
 	efiStorePath := filepath.Join(vp.config.WorkingDirectory, efiVariableStoreFileName)
 	serialLogFilePath := "/dev/null"
@@ -149,6 +149,19 @@ func (vp *VMProcess) buildDriverCommand() []string {
 		)
 	}
 
+	if vp.config.NestedVirtualization {
+		cpu, err := syscall.Sysctl("machdep.cpu.brand_string")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get CPU brand string: %w", err)
+		}
+
+		if strings.Contains(cpu, "M1") || strings.Contains(cpu, "M2") {
+			slog.Warn("nested virtualization is not supported, ignoring '--nested' flag")
+		} else {
+			cmd = append(cmd, "--nested")
+		}
+	}
+
 	if vp.config.Rosetta {
 		cmd = append(cmd, "--device", "rosetta,mountTag=rosetta")
 	}
@@ -157,7 +170,7 @@ func (vp *VMProcess) buildDriverCommand() []string {
 		cmd = append(cmd, "--device", fmt.Sprintf("virtio-fs,sharedDir=%s,mountTag=%s", path, tag))
 	}
 
-	return cmd
+	return cmd, nil
 }
 
 func (vp *VMProcess) getStateInfoRaw() (api.Data, error) {
@@ -327,7 +340,11 @@ func (vp *VMProcess) startVMProcess() error {
 		return fmt.Errorf("VM process is already running")
 	}
 
-	driverCommand := vp.buildDriverCommand()
+	driverCommand, err := vp.buildDriverCommand()
+	if err != nil {
+		return err
+	}
+
 	cmd := exec.Command(driverCommand[0], driverCommand[1:]...)
 	cmd.Dir = vp.config.WorkingDirectory
 


### PR DESCRIPTION
## Changes
- Added a new module option `services.virby.nestedVirtualization`
- Added `nested-virtualization` field to VM config JSON file
- Added CPU brand string check to `vm_process.go` when nested is enabled to verify compatibility; if incompatible, discard option (don't append `--nested` flag to driver command)